### PR TITLE
Fix to illegal dataTime value in VehicleSignals ontology

### DIFF
--- a/VS/VehicleSignals.rdf
+++ b/VS/VehicleSignals.rdf
@@ -40,7 +40,7 @@
 		<rdfs:label>Vehicle signals ontology (VS)</rdfs:label>
 		<rdfs:comment xml:lang="en">The GENIVI VSS Ontology (VSSO) has been initially created by Benjamin Klotz, Daniel Wilms, and Raphael Troncy (see http://automotive.eurecom.fr/vsso). VSSO, as created by Benjamin Klotz, Daniel Wilms, and Raphael Troncy, is available under the Creative Commons Attribution 4.0 International license; see http://creativecommons.org/licenses/by/4.0/. VSSO describes the car&apos;s attributes, branches and signals defined in GENIVI&apos;s Vehicle Signal Specification.</rdfs:comment>
 		<dct:abstract>This Vehicle Signals Ontology (VSSO) describes the car&apos;s parts and signals. It is based on the GENIVI&apos;s Vehicle Signal Specification.</dct:abstract>
-		<dct:created rdf:datatype="&xsd;dateTime">2018-01-10</dct:created>
+		<dct:created rdf:datatype="&xsd;dateTime">2018-01-10T00:00:00</dct:created>
 		<dct:license rdf:resource="http://creativecommons.org/licenses/by/4.0/"/>
 		<sm:fileAbbreviation>auto-ec-vsso</sm:fileAbbreviation>
 		<sm:filename>VehicleSignals.rdf</sm:filename>


### PR DESCRIPTION
Signed-off-by: mereolog <pawel.garbacz@makolab.com>

Fixes: #37 

"2018-01-10" changed to "2018-01-10T00:00:00