### PR TITLE
Fix missing imports

### DIFF
--- a/DE/TrafficIncidents.rdf
+++ b/DE/TrafficIncidents.rdf
@@ -47,6 +47,7 @@ In part, it is based on the Classification of Motor Vehicle Traffic Crashes (AME
 		<sm:filename>TrafficIncidents.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/auto/ontology/MO/MiddleOntology/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/auto/ontology/VC/VehicleCore/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 	</owl:Ontology>
 	

--- a/FD/Analytics.rdf
+++ b/FD/Analytics.rdf
@@ -1,0 +1,814 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE rdf:RDF [
+	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-fnd-arr-arr "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/">
+	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
+	<!ENTITY fibo-fnd-arr-doc "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/">
+	<!ENTITY fibo-fnd-arr-id "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/">
+	<!ENTITY fibo-fnd-dt-bd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/">
+	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
+	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
+	<!ENTITY fibo-fnd-plc-loc "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/">
+	<!ENTITY fibo-fnd-qt-qtu "https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/">
+	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
+	<!ENTITY fibo-fnd-utl-alx "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/">
+	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
+	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
+	<!ENTITY lcc-lr "https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/">
+	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
+	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+]>
+<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"
+	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-fnd-arr-arr="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"
+	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
+	xmlns:fibo-fnd-arr-doc="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"
+	xmlns:fibo-fnd-arr-id="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/"
+	xmlns:fibo-fnd-dt-bd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"
+	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
+	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
+	xmlns:fibo-fnd-plc-loc="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"
+	xmlns:fibo-fnd-qt-qtu="https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/"
+	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
+	xmlns:fibo-fnd-utl-alx="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"
+	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
+	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
+	xmlns:lcc-lr="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"
+	xmlns:owl="http://www.w3.org/2002/07/owl#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+	
+	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/">
+		<rdfs:label>Analytics Ontology</rdfs:label>
+		<dct:abstract>This ontology provides mathematical abstractions for use in other ontologies, including for example the basic components of formulae, parameters and values.</dct:abstract>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">https://www.w3.org/TR/owl2-quick-reference/</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2013-2021 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2021 Object Management Group, Inc.</sm:copyright>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
+		<sm:fileAbbreviation>fibo-fnd-utl-alx</sm:fileAbbreviation>
+		<sm:filename>Analytics.rdf</sm:filename>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20211101/Utilities/Analytics/"/>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20140501/Utilities/Analytics.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FND 1.0 FTF report and in https://spec.edmcouncil.org/fibo/ontology/FND/1.0/AboutFND-1.0/.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20141101/Utilities/Analytics.rdf version of this ontology was modified to address issue FIBOFND11-20, which added the definition of Calculation and corrected a reasoning issue related to the use of a custom datatype.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20160201/Utilities/Analytics.rdf version of this ontology was modified per the FIBO 2.0 RFC.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/Utilities/Analytics.rdf version of this ontology was modified to use the CombinedDateTime datatype for greater flexibility in analytics and integrate the generic statistical measures and measurements from the economic indicators ontology to FND to facilitate broader use.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190501/Utilities/Analytics.rdf version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Utilities/Analytics.rdf version of this ontology was modified to add the concept of a weighting algorithm.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20191101/Utilities/Analytics.rdf version of this ontology was modified to eliminate duplication with concepts in LCC, merge countries with locations, and correct a restriction on qualified measure.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Utilities/Analytics.rdf version of this ontology was modified to revise numeric index to be called numeric index value, and revise its definition to include a reference date, change its parent to quantity value, and move base date and period to scoped measure.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200401/Utilities/Analytics.rdf version of this ontology was modified to change the parent class of Classifier to Aspect, loosen the domain on the hasArgument property, which was too narrow in some cases, add a domain/range to characterizes/isCharacterizedBy, and eliminate duplicate properties that were not used anywhere.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200701/Utilities/Analytics.rdf version of this ontology was modified to augment the definition of ratio with a synonym of rate and eliminate the circularity in the definition of standard deviation.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200901/Utilities/Analytics.rdf version of this ontology was modified to make statistical program a subclass of program and revised restrictions on statistical program to better reflect its intent.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20201101/Utilities/Analytics.rdf version of this ontology was modified to eliminate the redundant &apos;calculation formula&apos; concept and eliminate the property hasOperand, which is not used anywhere and whose definition is circular.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20210201/Utilities/Analytics.rdf version of this ontology was modified to update the reference link for ratio.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20210601/Utilities/Analytics.rdf version of this ontology was modified to expand the definition of release date and release date and time and to make a statistical area identifier a subclass of geographic region identifier.</skos:changeNote>
+		<skos:changeNote>This ontology was added to Foundations in advance of the June 2014 Boston meeting in support of the IND RFC.</skos:changeNote>
+		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+	</owl:Ontology>
+	
+	<owl:Class rdf:about="&fibo-fnd-arr-cls;Classifier">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Aspect"/>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-qt-qtu;Quantity">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Measure"/>
+	</owl:Class>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;characterizes">
+		<rdfs:domain rdf:resource="&fibo-fnd-utl-alx;Aspect"/>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;isCharacterizedBy">
+		<rdfs:range rdf:resource="&fibo-fnd-utl-alx;Aspect"/>
+	</owl:ObjectProperty>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;AnnualizedStandardDeviation">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;StandardDeviation"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasReferencePeriod"/>
+				<owl:onClass rdf:resource="&fibo-fnd-dt-fd;ExplicitRecurrenceInterval"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>annualized standard deviation</rdfs:label>
+		<skos:definition>standard deviation for some measure over a specific reference period</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>Standard deviation applied to the annual rate of return of an investment provides insights on the historical volatility of that investment. The greater the standard deviation of the price of a security, the greater the volatility.  Multiplying monthly standard deviation by the square root of twelve (12) is an industry standard method of approximating annualized standard deviations of monthly returns.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;ArithmeticMean">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Mean"/>
+		<rdfs:label>arithmetic mean</rdfs:label>
+		<skos:definition>sum of a collection of numbers divided by the number of numbers in the collection</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>While the arithmetic mean is often used to report central tendencies, it is not a robust statistic, meaning that it is greatly influenced by outliers (values that are very much larger or smaller than most of the values). Notably, for skewed distributions, such as the distribution of income for which a few people&apos;s incomes are substantially greater than most people&apos;s, the arithmetic mean may not accord with one&apos;s notion of &apos;middle&apos;, and robust statistics, such as the median, may be a better description of central tendency.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;Aspect">
+		<rdfs:label>aspect</rdfs:label>
+		<skos:definition>characteristic or feature that can be used to dimensionalize, filter, or subset something</skos:definition>
+		<fibo-fnd-utl-av:synonym>dimension</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym>filter</fibo-fnd-utl-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;AverageAbsoluteDeviation">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Dispersion"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasArgument"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-fnd-utl-alx;Mean">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-fnd-utl-alx;Median">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>average absolute deviation</rdfs:label>
+		<skos:definition>average of the absolute deviations from a central point</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>The central point can be the mean, median, mode, or the result of another measure of central tendency. Absolute deviation is the distance between each value in the data set and that data set&apos;s mean or median.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym>mean absolute deviation</fibo-fnd-utl-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;Constant">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-rel-rel;Reference"/>
+		<rdfs:label>constant</rdfs:label>
+		<skos:definition>symbol that represents a value that does not change (i.e., is fixed) with respect to a formula or expression</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;Difference">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Expression"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;StatisticalMeasure"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasMinuend"/>
+				<owl:cardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:cardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasSubtrahend"/>
+				<owl:cardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:cardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>difference</rdfs:label>
+		<skos:definition>quantity by which amounts differ; the remainder left after subtraction of one value from another</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;Dispersion">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Expression"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;StatisticalMeasure"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-arr-arr;hasCollectionSize"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&xsd;nonNegativeInteger"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-utl-alx;FinitePopulation"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasObservedValue"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-arr-arr;StructuredCollection"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>dispersion</rdfs:label>
+		<skos:definition>degree of scatter or variability shown by observations</skos:definition>
+		<skos:example>Common examples of measures of statistical dispersion are the variance, standard deviation, and interquartile range.  The collection size argument, above, represents the number of elements in the set, if known. The collection of values under consideration is represented as a structured collection in FIBO, typically a sample set derived from a finite population.</skos:example>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://stats.oecd.org/glossary/detail.asp?ID=3637</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>A measure of statistical dispersion is a nonnegative real number that is zero if all the data are the same and increases as the data become more diverse.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>It is usually measured as an average deviation about some central value (e.g. mean deviation, standard deviation) or by an order statistic (e.g. quartile deviation, range) but may also be a mean of deviations of values among themselves (e.g. Gini&apos;s mean difference and also standard deviation).</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;Expression">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-rel-rel;Reference"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasArgument"/>
+				<owl:onClass rdf:resource="&fibo-fnd-utl-alx;Constant"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasArgument"/>
+				<owl:onClass rdf:resource="&fibo-fnd-utl-alx;Variable"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>expression</rdfs:label>
+		<skos:definition>finite combination of symbols that are well-formed according to applicable rules</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;FinitePopulation">
+		<rdfs:subClassOf rdf:resource="&lcc-lr;Collection"/>
+		<rdfs:label>finite population</rdfs:label>
+		<skos:definition>population for which it is possible to count its units</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://stats.oecd.org/glossary/detail.asp?ID=3649</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>In statistics, a population is a set of similar items or events of interest for some question or experiment. In other words, a population is the complete group of units to which survey results are to apply. (These units may be persons, animals, objects, businesses, trips, etc.). See http://www.statcan.gc.ca/edu/power-pouvoir/glossary-glossaire/5214842-eng.htm#p.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;Formula">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-rel-rel;Reference"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasExpression"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-utl-alx;Expression"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>formula</rdfs:label>
+		<skos:definition>rule expressed in letters and symbols that consists of at least one expression</skos:definition>
+		<fibo-fnd-utl-av:synonym>complex expression</fibo-fnd-utl-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;GeometricMean">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Mean"/>
+		<rdfs:label>geometric mean</rdfs:label>
+		<skos:definition>mean that indicates the central tendency or typical value of a set of numbers by using the product of their values (as opposed to the arithmetic mean which uses their sum)</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>The geometric mean is defined as the nth root of the product of n numbers. A geometric mean is often used when comparing different items - finding a single &apos;figure of merit&apos; for these items - when each item has multiple properties that have different numeric ranges. For example, the geometric mean can give a meaningful &apos;average&apos; to compare two companies which are each rated at 0 to 5 for their environmental sustainability, and are rated at 0 to 100 for their financial viability. If an arithmetic mean were used instead of a geometric mean, the financial viability is given more weight because its numeric range is larger - so a small percentage change in the financial rating (e.g. going from 80 to 90) makes a much larger difference in the arithmetic mean than a large percentage change in environmental sustainability (e.g. going from 2 to 5).</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;Mean">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Expression"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;StatisticalMeasure"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasObservedValue"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-arr-arr;StructuredCollection"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>mean</rdfs:label>
+		<skos:definition>most common measure of central tendency; the average of a set of numbers</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.statcan.gc.ca/edu/power-pouvoir/glossary-glossaire/5214842-eng.htm#m</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://stats.oecd.org/glossary/detail.asp?ID=3762</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.census.gov/glossary/#term_Mean</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>When unqualified, the mean usually refers to the expectation of a variate, or to the arithmetic mean of a sample used as an estimate of the expectation.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:symbol>μ</fibo-fnd-utl-av:symbol>
+		<fibo-fnd-utl-av:synonym>expected value</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym>first (raw) moment</fibo-fnd-utl-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;Measure">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-rel-rel;Reference"/>
+		<rdfs:label>measure</rdfs:label>
+		<skos:definition>amount or degree of something; the dimensions, capacity, or amount of something ascertained by measuring</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://stats.oecd.org/glossary/detail.asp?ID=7062</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>Measure refers to the phenomenon or phenomena to be measured in a data set. In a data set, the instance of a measure is often called an observation.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;Median">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Expression"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;StatisticalMeasure"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasObservedValue"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-arr-arr;StructuredCollection"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>median</rdfs:label>
+		<skos:definition>value of the variate dividing the total frequency of a data sample, population, or probability distribution, into two halves</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://stats.oecd.org/glossary/detail.asp?ID=3717</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.census.gov/glossary/#term_Median</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>The basic advantage of the median in describing data compared to the mean is that it is not skewed by extremely large or small values, and may provide a better idea of a &apos;typical&apos; value.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>This measure represents the middle value (if n is odd) or the average of the two middle values (if n is even) in an ordered list of data values. The median divides the total frequency distribution into two equal parts: one-half of the cases fall below the median and one-half of the cases exceed the median.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;MedianAbsoluteDeviation">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Dispersion"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasArgument"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-utl-alx;Median"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>median absolute deviation</rdfs:label>
+		<skos:definition>median of the absolute deviations of observations from the average which may be the arithmetic mean, the median or the mode</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;NumericIndexValue">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-qt-qtu;QuantityValue"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;isValueOf"/>
+				<owl:onClass rdf:resource="&fibo-fnd-utl-alx;ScopedMeasure"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasMeasurementDateTime"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&fibo-fnd-dt-fd;CombinedDateTime"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>numeric index value</rdfs:label>
+		<skos:definition>numeric value of some aggregate relative to the value of that aggregate as of some date</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.statcan.gc.ca/edu/power-pouvoir/glossary-glossaire/5214842-eng.htm#i</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>A mathematical device or number which is used to express the observation (e.g., price level, volume of trade, relative amount etc.) of a given period, in comparison with that of a prior period.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;Percentage">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;RatioValue"/>
+		<rdfs:label>percentage</rdfs:label>
+		<skos:definition>ratio value expressed as a fraction of 100, i.e., in which the denominator is fixed rather than variable and equal to 100</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>The percent value is computed by multiplying the numeric value of the ratio by 100.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>While many percentage values are between 0 and 100, there is no mathematical restriction and percentages may take on other values (positive or negative), particularly in the case of comparisons (percent change).</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;QualifiedMeasure">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;StatisticalMeasure"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasAnchorDate"/>
+				<owl:onClass rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;isCalculatedViaMethodology"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onDataRange>
+					<rdfs:Datatype>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&xsd;string">
+							</rdf:Description>
+							<rdf:Description rdf:about="&xsd;anyURI">
+							</rdf:Description>
+						</owl:unionOf>
+					</rdfs:Datatype>
+				</owl:onDataRange>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>qualified measure</rdfs:label>
+		<skos:definition>statistical measure that is constrained by features, quantity kinds or units that refine how it is calculated</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;Ratio">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Expression"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;StatisticalMeasure"/>
+		<rdfs:label>ratio</rdfs:label>
+		<skos:definition>proportional relationship between two different numbers or quantities, or in mathematics a quotient of two numbers or expressions, arrived at by dividing one by the other</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://stats.oecd.org/glossary/detail.asp?ID=6688</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www150.statcan.gc.ca/n1/edu/power-pouvoir/glossary-glossaire/5214842-eng.htm#r.</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>A ratio is a quantity measured with respect to some other quantity.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym>rate</fibo-fnd-utl-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;RatioValue">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-qt-qtu;QuantityValue"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasArgument"/>
+				<owl:onClass rdf:resource="&fibo-fnd-utl-alx;Variable"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>ratio value</rdfs:label>
+		<skos:definition>proportional relationship specifically between two different quantity values that gives rise to a datum of a specific quantity type</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;SamplingVariance">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Variance"/>
+		<rdfs:label>sampling variance</rdfs:label>
+		<skos:definition>measure of the extent to which the estimate of a characteristic from different possible samples of the same size and the same design differ from one another</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.statcan.gc.ca/pub/12-587-x/12-587-x2003001-eng.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://stats.oecd.org/glossary/detail.asp?ID=3834</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>The word &apos;sampling&apos; can usually be omitted, as being defined by the context or otherwise understood. The sampling variance of a statistic is the square of its standard error.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;ScopedMeasure">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;QualifiedMeasure"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasPeriodicity"/>
+				<owl:allValuesFrom rdf:resource="&fibo-fnd-dt-fd;RecurrenceInterval"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
+				<owl:onClass rdf:resource="&fibo-fnd-utl-alx;FinitePopulation"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-plc-loc;hasCoverageArea"/>
+				<owl:onClass rdf:resource="&fibo-fnd-utl-alx;StatisticalArea"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>scoped measure</rdfs:label>
+		<skos:definition>qualified measure that is constrained by filters on the statistical population to which it applies</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>Note that (1) the anchor date reflects the start of the current series, such as 1982-1984 for the CPI, (2) the fixed comparative date might be something like March 2009, if one is comparing a current index against its value at the end of the great recession, (3) the relative comparative date might be something like a month or year ago, depending on the analysis requirements, and (4) the relative comparative period might be a 3 month average prior value, again depending on the analysis requirements.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;StandardDeviation">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Dispersion"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasArgument"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-fnd-utl-alx;Mean">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-fnd-utl-alx;Variance">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>standard deviation</rdfs:label>
+		<skos:definition>square root of variance that measures the spread or dispersion around the mean of a data set</skos:definition>
+		<fibo-fnd-utl-av:abbreviation>SD</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.statcan.gc.ca/edu/power-pouvoir/glossary-glossaire/5214842-eng.htm#s</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://stats.oecd.org/glossary/detail.asp?ID=3845</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.census.gov/glossary/#term_Standarddeviation</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>The most widely used measure of dispersion of a frequency distribution introduced by K. Pearson (1893). It is equal to the positive square root of the variance. The standard deviation should not be confused with the root mean square deviation.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>While standard deviation is the most widely-used measure of spread, using squared deviations, it may not be the most robust.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:symbol>σ</fibo-fnd-utl-av:symbol>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;StatisticalArea">
+		<rdfs:subClassOf rdf:resource="&lcc-cr;GeographicRegion"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;isIdentifiedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-utl-alx;StatisticalAreaIdentifier"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>statistical area</rdfs:label>
+		<skos:definition>physical location that is defined per some program for designating geographic regions for the purposes of tabulating and presenting statistical data</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/display/IND/Statistics+Canada+Census+Information</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/pages/viewpage.action?pageId=6358041</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom rdf:resource="http://www.census.gov/prod/cen2010/doc/gqsf.pdf"/>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;StatisticalAreaIdentifier">
+		<rdfs:subClassOf rdf:resource="&lcc-cr;GeographicRegionIdentifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;identifies"/>
+				<owl:onClass rdf:resource="&fibo-fnd-utl-alx;StatisticalArea"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>statistical area identifier</rdfs:label>
+		<skos:definition>identifier for a physical location that is defined per a nationally consistent program for designating geographic regions for the purposes of tabulating and presenting statistical data</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/display/IND/Statistics+Canada+Census+Information</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/pages/viewpage.action?pageId=6358041</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom rdf:resource="http://www.census.gov/prod/cen2010/doc/gqsf.pdf"/>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;StatisticalMeasure">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Measure"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isCharacterizedBy"/>
+				<owl:onClass rdf:resource="&fibo-fnd-utl-alx;Aspect"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;isEstimate"/>
+				<owl:onDataRange rdf:resource="&xsd;boolean"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>statistical measure</rdfs:label>
+		<skos:definition>summary (means, mode, total, index, etc.) of the individual quantitative variable values for the statistical units in a specific group (study domain)</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://stats.oecd.org/glossary/detail.asp?ID=5068</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>Statistical measures may consist of several orthogonal characteristics, including (a) whether they reflect an estimate or variable, (b) the datatype, or from a FIBO perspective, nature of the measure (e.g., index, total, ratio, percent, percent change, mean, others), (c) the population (or the universe that applies to the highest level if defined in general) to which the measure applies, and (d) any relevant aspects used to subset or stratify a measure, (i.e., make them apply to a smaller universe).</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;StatisticalPopulation">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;FinitePopulation"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;StatisticalUniverse"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasPopulationSize"/>
+				<owl:allValuesFrom rdf:resource="&xsd;nonNegativeInteger"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isCharacterizedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-fd;ExplicitDatePeriod"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isCharacterizedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-utl-alx;StatisticalArea"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>statistical population</rdfs:label>
+		<skos:definition>statistical universe filtered by time and region</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom rdf:resource="http://stats.oecd.org/glossary/detail.asp?ID=2079"/>
+		<fibo-fnd-utl-av:explanatoryNote>A common aim of statistical analysis is to produce information about some chosen population. In statistical inference, a subset of the population (a statistical sample) is chosen to represent the population in a statistical analysis. If a sample is chosen properly, characteristics of the entire population that the sample is drawn from can be estimated from corresponding characteristics of the sample.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;StatisticalProgram">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;Program"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-plc-loc;hasCoverageArea"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-utl-alx;StatisticalArea"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-utl-alx;StatisticalUniverse"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;provides"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-utl-alx;StatisticalMeasure"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>statistical program</rdfs:label>
+		<skos:definition>program that presents a detailed investigation and analysis of a subject or situation involving one or more studies or surveys</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;StatisticalUniverse">
+		<rdfs:subClassOf rdf:resource="&lcc-lr;Collection"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasUniverseSize"/>
+				<owl:allValuesFrom rdf:resource="&xsd;nonNegativeInteger"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasContext"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-utl-alx;StatisticalProgram"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>statistical universe</rdfs:label>
+		<skos:definition>collection representing the total membership, or &apos;universe&apos;, of people, resources, products, services, events, or entities of interest for some question, experiment, survey or statistical program</skos:definition>
+		<skos:example>A statistical universe can be a group of actually existing objects (e.g. the set of all stars within the Milky Way galaxy) or a hypothetical and potentially infinite group of objects conceived as a generalization from experience (e.g. the set of all possible hands in a game of poker).</skos:example>
+		<fibo-fnd-utl-av:adaptedFrom rdf:resource="http://stats.oecd.org/glossary/detail.asp?ID=2087"/>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;Total">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Expression"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;StatisticalMeasure"/>
+		<rdfs:label>total</rdfs:label>
+		<skos:definition>sum of the values for some characteristic of all units</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;Variable">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-rel-rel;Reference"/>
+		<rdfs:label>variable</rdfs:label>
+		<skos:definition>symbol that represents a parameter in a formula or expression</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;Variance">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Dispersion"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasArgument"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-utl-alx;Mean"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>variance</rdfs:label>
+		<skos:definition>measure of spread, calculated as the average squared deviation of each number from the mean of a data set</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.statcan.gc.ca/edu/power-pouvoir/glossary-glossaire/5214842-eng.htm#v</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:symbol>μ2</fibo-fnd-utl-av:symbol>
+		<fibo-fnd-utl-av:symbol>σ2</fibo-fnd-utl-av:symbol>
+		<fibo-fnd-utl-av:synonym>second moment</fibo-fnd-utl-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-alx;WeightingFunction">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Expression"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;StatisticalMeasure"/>
+		<rdfs:label>weighting function</rdfs:label>
+		<skos:definition>expression or function that determines the relative importance or influence of a given element of a set with respect to the whole</skos:definition>
+		<skos:example>Given a sample size of 1000, and a population of 300M, then the chance that any individual is selected is 1 in 300K.  In that case, 300K is the weight assigned to each of the elements in the sample. 
+For certain indices, one of the most common weighting factor is by market capitalization.  In that case, each of the elements in the basket is multiplied by its market cap to determine its relative importance to the basket overall.</skos:example>
+		<fibo-fnd-utl-av:explanatoryNote>With respect to discrete calculations, weighting functions are positive functions defined on discrete sets, such as weighted sums and weighted averages.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:AnnotationProperty rdf:about="&fibo-fnd-utl-alx;actualExpression">
+		<rdfs:label>actual expression</rdfs:label>
+		<rdfs:range rdf:resource="&xsd;string"/>
+		<skos:definition>specifies the calculation or expression used to determine the value of something</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>In cases where some expression can only be calculated in SPARQL or via rules, this property is useful for stating what that calculation should be using the input arguments to the expression.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:AnnotationProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-utl-alx;hasAnchorDate">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasExplicitDate"/>
+		<rdfs:label>has anchor date</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
+		<skos:definition>specifies the base date against which the value of a numeric index for a more recent date is compared (i.e., the starting point from which it stems)</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-utl-alx;hasApplicableDatePeriod">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDatePeriod"/>
+		<rdfs:label>has applicable date period</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fnd-utl-alx;StatisticalMeasure"/>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;DatePeriod"/>
+		<skos:definition>indicates the date period for which the statistical measure is applicable</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-utl-alx;hasArgument">
+		<rdfs:subPropertyOf rdf:resource="&lcc-lr;has"/>
+		<rdfs:label>has argument</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-utl-alx;Variable"/>
+		<skos:definition>indicates a specific input to a function, formula or expression, also known as an independent variable</skos:definition>
+		<fibo-fnd-utl-av:synonym>has independent variable</fibo-fnd-utl-av:synonym>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-utl-alx;hasExpression">
+		<rdfs:subPropertyOf rdf:resource="&lcc-lr;has"/>
+		<rdfs:label>has expression</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fnd-rel-rel;Reference"/>
+		<rdfs:range rdf:resource="&fibo-fnd-utl-alx;Expression"/>
+		<skos:definition>specifies a mathematical or other formal expression, which may be part of a formula</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-utl-alx;hasFixedComparativeDate">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasExplicitDate"/>
+		<rdfs:label>has fixed comparative date</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
+		<skos:definition>specifies the a specific date, such as the end of the last recession (e.g., March 2009) against which the scoped measure is compared</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-utl-alx;hasFormula">
+		<rdfs:subPropertyOf rdf:resource="&lcc-lr;has"/>
+		<rdfs:label>has formula</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-utl-alx;Formula"/>
+		<skos:definition>specifies a concise way of expressing information symbolically, as in a mathematical or chemical formula</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&fibo-fnd-utl-alx;hasMeasurementDateTime">
+		<rdfs:label>has measurement date time</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;CombinedDateTime"/>
+		<skos:definition>indicates the date and time that the measurement was taken</skos:definition>
+	</owl:DatatypeProperty>
+	
+	<owl:DatatypeProperty rdf:about="&fibo-fnd-utl-alx;hasMeasurementPeriodInMonths">
+		<rdfs:label>has measurement period in months</rdfs:label>
+		<rdfs:range rdf:resource="&xsd;integer"/>
+		<skos:definition>indicates the coverage period for which the measure is applicable expressed in months</skos:definition>
+	</owl:DatatypeProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-utl-alx;hasMinuend">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-utl-alx;hasArgument"/>
+		<rdfs:label>has minuend</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fnd-utl-alx;Difference"/>
+		<skos:definition>specifies the quantity value from which something is subtracted; the value that is diminished</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&fibo-fnd-utl-alx;hasNumberOfEntries">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasCount"/>
+		<rdfs:label>has number of entries</rdfs:label>
+		<rdfs:range rdf:resource="&xsd;nonNegativeInteger"/>
+		<skos:definition>indicates the number of elements in some document, table, or other resource (e.g., in a report, table)</skos:definition>
+	</owl:DatatypeProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-utl-alx;hasObservedValue">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-utl-alx;hasArgument"/>
+		<rdfs:label>has observed value</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-arr-arr;StructuredCollection"/>
+		<skos:definition>specifies a collection of values over which some analysis is performed</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>For certain calculations, such as certain measures of dispersion, date value pairs are expected as input, in other words, a dated structured collection.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-utl-alx;hasPeriodicity">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasRecurrenceInterval"/>
+		<rdfs:label>has periodicity</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;RecurrenceInterval"/>
+		<skos:definition>specifies a recurrence interval (monthly, quarterly, annual) that a statistical measure reflects</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&fibo-fnd-utl-alx;hasPopulationSize">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-arr-arr;hasCollectionSize"/>
+		<rdfs:label>has population size</rdfs:label>
+		<rdfs:range rdf:resource="&xsd;nonNegativeInteger"/>
+		<skos:definition>indicates the number of elements in a given population</skos:definition>
+	</owl:DatatypeProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-utl-alx;hasReferencePeriod">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasRecurrenceInterval"/>
+		<rdfs:label>has reference period</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;RecurrenceInterval"/>
+		<skos:definition>specifies a reference (baseline) recurrence interval for which a given measure applies</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-utl-alx;hasRelativeComparativeDate">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDate"/>
+		<rdfs:label>has relative comparative date</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;RelativeDate"/>
+		<skos:definition>specifies a date against which the value of a scoped measure is compared (e.g., one month prior, three months prior, etc., and typically against a prior release or average over prior releases)</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-utl-alx;hasRelativeComparativePeriod">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDatePeriod"/>
+		<rdfs:label>has relative comparative period</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;DatePeriod"/>
+		<skos:definition>specifies a period (typically a prior period) against which the scoped measure is compared, such as an average set of values for some period of time compared with a more recent or projected average for a forward looking period of time</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-utl-alx;hasReleaseDate">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDate"/>
+		<rdfs:label>has release date</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<skos:definition>specifies the date on which something is published</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>A release date is typically a date fixed in advance for the release of a film, recording, document, report, or product or publication.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&fibo-fnd-utl-alx;hasReleaseDateTime">
+		<rdfs:label>has release date and time</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;CombinedDateTime"/>
+		<skos:definition>specifies the date and time on which something is published</skos:definition>
+	</owl:DatatypeProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-utl-alx;hasSubtrahend">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-utl-alx;hasArgument"/>
+		<rdfs:label>has subtrahend</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fnd-utl-alx;Difference"/>
+		<skos:definition>specifies the quantity value that is subtracted from something</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&fibo-fnd-utl-alx;hasUniverseSize">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-arr-arr;hasCollectionSize"/>
+		<rdfs:label>has universe size</rdfs:label>
+		<rdfs:range rdf:resource="&xsd;nonNegativeInteger"/>
+		<skos:definition>indicates the number of elements in a given universe</skos:definition>
+	</owl:DatatypeProperty>
+	
+	<owl:DatatypeProperty rdf:about="&fibo-fnd-utl-alx;hasWeight">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-qt-qtu;hasNumericValue"/>
+		<rdfs:label>has weight</rdfs:label>
+		<rdfs:range rdf:resource="&xsd;decimal"/>
+		<skos:definition>indicates an amount given to increase or decrease the importance of an item</skos:definition>
+	</owl:DatatypeProperty>
+	
+	<owl:DatatypeProperty rdf:about="&fibo-fnd-utl-alx;isCalculatedViaMethodology">
+		<rdfs:label>is calculated via methodology</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fnd-utl-alx;StatisticalMeasure"/>
+		<skos:definition>high-level description of the approach taken to obtain the result</skos:definition>
+	</owl:DatatypeProperty>
+	
+	<owl:DatatypeProperty rdf:about="&fibo-fnd-utl-alx;isEstimate">
+		<rdfs:label>is estimate</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fnd-utl-alx;StatisticalMeasure"/>
+		<rdfs:range rdf:resource="&xsd;boolean"/>
+		<skos:definition>indicates whether the measure reflects an estimate (approximation) or not</skos:definition>
+	</owl:DatatypeProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-utl-alx;isValueOf">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
+		<rdfs:label>is value of</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fnd-qt-qtu;QuantityValue"/>
+		<skos:definition>is the measure that the value represents</skos:definition>
+	</owl:ObjectProperty>
+
+</rdf:RDF>

--- a/FD/AnnotationVocabulary.rdf
+++ b/FD/AnnotationVocabulary.rdf
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE rdf:RDF [
+	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
+	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
+	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+]>
+<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
+	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
+	xmlns:owl="http://www.w3.org/2002/07/owl#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+	
+	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
+		<rdfs:label>Annotation Vocabulary</rdfs:label>
+		<dct:abstract>This vocabulary provides a set of metadata annotations for use in describing FIBO ontology elements.  The annotations extend properties defined in the OMG&apos;s Specification Metadata Recommendation, in the Dublin Core Metadata Terms Vocabulary and in the W3C Simple Knowledge Organization System (SKOS) Vocabulary, and have been customized to suit the FIBO specification development process.  
+
+Note that any of the original properties provided in Dublin Core and SKOS can be used in addition to the terms provided herein.  However, any Dublin Core terms that are not explicitly defined as OWL annotation properties in this ontology or in any of its imports must be so declared in the ontologies that use them.</dct:abstract>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:fileAbbreviation>fibo-fnd-utl-av</sm:fileAbbreviation>
+		<sm:filename>AnnotationVocabulary.rdf</sm:filename>
+		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
+		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Utilities/AnnotationVocabulary/"/>
+		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20130801/Utilities/AnnotationVocabulary.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FND 1.0 FTF report and in http://www.omg.org/spec/EDMC-FIBO/FND/1.0/AboutFND-1.0/.</skos:changeNote>
+		<skos:changeNote>The http://www.omg.org/spec/FIBO/Foundations/20130601/Utilities/AnnotationVocabulary.owl version of the ontology was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
+   (1) to use slash style URI/IRIss (also called 303 URIs, vs. hash style) as required to support server side processing 
+   (2) to use version-independent IRIs for all definitions internally as opposed to version-specific IRIs
+   (3) to change the file suffix from .owl to .rdf to increase usability in RDF tools
+   (4) to use 4-level abbreviations and corresponding namespace prefixes for all FIBO ontologies, reflecting a family/specification/module/ontology structure
+   (5) to incorporate changes to the specification metadata to support documentation at the family, specification, module, and ontology level, similar to the abbreviations</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/Utilities/AnnotationVocabulary.rdf version of this ontology was modified to add the symbol annotation.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190501/Utilities/AnnotationVocabulary.rdf version of this ontology was modified to eliminate deprecated properties.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Utilities/AnnotationVocabulary.rdf version of this ontology was modified to add common and preferred designations as needed for postal addresses and other purposes, to correct named individuals to be properly declared, and to revise definitions to be ISO 704 compliant.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Utilities/AnnotationVocabulary.rdf version of this ontology was modified to eliminate skos:Concept as a superclass of MaturityLevel (replaced with LifecycleStage in the Lifecycles ontology), revise explanatory notes for maturity levels based on community feedback, and correct the subproperty inheritance for adaptedFrom and logicalDefinition.</skos:changeNote>
+		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+	</owl:Ontology>
+	
+	<owl:AnnotationProperty rdf:about="&dct;modified">
+	</owl:AnnotationProperty>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-utl-av;Informative">
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;MaturityLevel"/>
+		<rdfs:label>informative</rdfs:label>
+		<skos:definition xml:lang="en">entity that is considered deprecated but included for informational purposes because it is referenced by some provisional concept</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Informative content will be removed as soon as all dependencies have been eliminated, thus FIBO users should not depend on it going forward.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-av;MaturityLevel">
+		<rdfs:label>maturity level</rdfs:label>
+		<skos:definition>classifier used to indicate state of an artifact with respect to its development lifecycle</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">FIBO currently has three maturity levels: Informative, Provisional, and Release.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-utl-av;Provisional">
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;MaturityLevel"/>
+		<rdfs:label>provisional</rdfs:label>
+		<skos:definition xml:lang="en">entity that is considered to be under development</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Provisional content is subject to change, and may change substantially prior to release. FIBO users should be aware that it is not dependable, but could be used for reference and as the basis for further work.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-utl-av;Release">
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;MaturityLevel"/>
+		<rdfs:label>release</rdfs:label>
+		<skos:definition xml:lang="en">entity that is considered to be stable and mature from a development perspective</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Release notes will be provided for any changes with respect to released content, and any revisions will be backwards compatible with the prior version to the degree possible.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:NamedIndividual>
+	
+	<owl:AnnotationProperty rdf:about="&fibo-fnd-utl-av;abbreviation">
+		<rdfs:subPropertyOf rdf:resource="&skos;altLabel"/>
+		<rdfs:label>abbreviation</rdfs:label>
+		<skos:definition>short form designation for an entity that can be substituted for its primary representation</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom>ISO 1087-1 Terminology work - Vocabulary</fibo-fnd-utl-av:adaptedFrom>
+	</owl:AnnotationProperty>
+	
+	<owl:AnnotationProperty rdf:about="&fibo-fnd-utl-av;adaptedFrom">
+		<rdfs:subPropertyOf rdf:resource="&dct;source"/>
+		<rdfs:label>adapted from</rdfs:label>
+		<skos:definition>document or other source from which a given term (or its definition) was adapted; the range for this annotation can be a string, URI, or BibliographicCitation</skos:definition>
+	</owl:AnnotationProperty>
+	
+	<owl:AnnotationProperty rdf:about="&fibo-fnd-utl-av;commonDesignation">
+		<rdfs:subPropertyOf rdf:resource="&skos;altLabel"/>
+		<rdfs:label>common designation</rdfs:label>
+		<skos:definition>frequently used designation for an entity</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://pe.usps.com/cpim/ftp/pubs/Pub28/pub28.pdf</fibo-fnd-utl-av:adaptedFrom>
+	</owl:AnnotationProperty>
+	
+	<owl:AnnotationProperty rdf:about="&fibo-fnd-utl-av;definitionOrigin">
+		<rdfs:subPropertyOf rdf:resource="&sm;directSource"/>
+		<rdfs:label>definition origin</rdfs:label>
+		<skos:definition>document or other source from which a given definition was taken directly; the range for this annotation can be a string, URI, or BibliographicCitation</skos:definition>
+	</owl:AnnotationProperty>
+	
+	<owl:AnnotationProperty rdf:about="&fibo-fnd-utl-av;explanatoryNote">
+		<rdfs:subPropertyOf rdf:resource="&skos;note"/>
+		<rdfs:label>explanatory note</rdfs:label>
+		<skos:definition>note that provides additional explanatory information about a given concept</skos:definition>
+	</owl:AnnotationProperty>
+	
+	<owl:AnnotationProperty rdf:about="&fibo-fnd-utl-av;hasMaturityLevel">
+		<rdfs:label>has maturity level</rdfs:label>
+		<skos:definition>links something to its state with respect to a development lifecycle</skos:definition>
+	</owl:AnnotationProperty>
+	
+	<owl:AnnotationProperty rdf:about="&fibo-fnd-utl-av;logicalDefinition">
+		<rdfs:subPropertyOf rdf:resource="&skos;definition"/>
+		<rdfs:label>logical definition</rdfs:label>
+		<skos:definition>description of the OWL logic of a model element in natural language</skos:definition>
+	</owl:AnnotationProperty>
+	
+	<owl:AnnotationProperty rdf:about="&fibo-fnd-utl-av;modifiedBy">
+		<rdfs:subPropertyOf rdf:resource="&sm;contributor"/>
+		<rdfs:label>modified by</rdfs:label>
+		<skos:definition>organization or person responsible for making a change to a model element</skos:definition>
+	</owl:AnnotationProperty>
+	
+	<owl:AnnotationProperty rdf:about="&fibo-fnd-utl-av;modifiedOn">
+		<rdfs:subPropertyOf rdf:resource="&dct;modified"/>
+		<rdfs:label>modified on</rdfs:label>
+		<skos:definition>date a model element was changed</skos:definition>
+	</owl:AnnotationProperty>
+	
+	<owl:AnnotationProperty rdf:about="&fibo-fnd-utl-av;preferredDesignation">
+		<rdfs:subPropertyOf rdf:resource="&skos;altLabel"/>
+		<rdfs:label>preferred designation</rdfs:label>
+		<skos:definition>recommended designation for an entity in some context</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://pe.usps.com/cpim/ftp/pubs/Pub28/pub28.pdf</fibo-fnd-utl-av:adaptedFrom>
+	</owl:AnnotationProperty>
+	
+	<owl:AnnotationProperty rdf:about="&fibo-fnd-utl-av;symbol">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-utl-av;abbreviation"/>
+		<rdfs:label>symbol</rdfs:label>
+		<skos:definition>abbreviation that is a design, mark, or character(s) used conventionally to represent something, such as a currency, quantity, or variable in an expression</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom>ISO 31-0 Quantities and units - General principles</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>The symbols for quantities are generally single letters of the Latin or Greek alphabet, sometimes with subscripts or other modifying signs.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:AnnotationProperty>
+	
+	<owl:AnnotationProperty rdf:about="&fibo-fnd-utl-av;synonym">
+		<rdfs:subPropertyOf rdf:resource="&skos;altLabel"/>
+		<rdfs:label>synonym</rdfs:label>
+		<skos:definition>designation that can be substituted for the primary representation of something</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom>ISO 1087-1 Terminology work - Vocabulary</fibo-fnd-utl-av:adaptedFrom>
+	</owl:AnnotationProperty>
+	
+	<owl:AnnotationProperty rdf:about="&fibo-fnd-utl-av;termOrigin">
+		<rdfs:subPropertyOf rdf:resource="&sm;directSource"/>
+		<rdfs:label>term origin</rdfs:label>
+		<skos:definition>document or other source from which a given term was taken directly; the range for this annotation can be a string, URI, or BibliographicCitation</skos:definition>
+	</owl:AnnotationProperty>
+	
+	<owl:AnnotationProperty rdf:about="&fibo-fnd-utl-av;usageNote">
+		<rdfs:subPropertyOf rdf:resource="&skos;note"/>
+		<rdfs:label>usage note</rdfs:label>
+		<skos:definition>note that provides information about how a given concept should be used or extended</skos:definition>
+	</owl:AnnotationProperty>
+
+</rdf:RDF>

--- a/VC/VehicleParts.rdf
+++ b/VC/VehicleParts.rdf
@@ -49,6 +49,7 @@ It contains many classes and properties extracted from:
 		<sm:fileAbbreviation>auto-vp</sm:fileAbbreviation>
 		<sm:filename>VehicleParts.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/auto/ontology/MO/MiddleOntology/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 	</owl:Ontology>
 	

--- a/VS/VehicleSignals.rdf
+++ b/VS/VehicleSignals.rdf
@@ -45,6 +45,7 @@
 		<sm:fileAbbreviation>auto-ec-vsso</sm:fileAbbreviation>
 		<sm:filename>VehicleSignals.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/auto/ontology/VC/VehicleParts/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 	</owl:Ontology>
 	


### PR DESCRIPTION
This fixes #55 by:
1. adding required import statements
2. TEMPORARILY adding imported FIBO ontologies until https://github.com/edmcouncil/ontology-publisher/issues/66 is fixed.

This PR needs to be run BEFORE PR #54.