### PR TITLE
Multiple labels in MiddleOntology and VehicleCore and missing label in TrafficEnvironment

### DIFF
--- a/DE/TrafficEnvironment.rdf
+++ b/DE/TrafficEnvironment.rdf
@@ -926,6 +926,7 @@
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&auto-ev;angle">
+		<rdfs:label>Angle</rdfs:label>
 		<rdfs:domain rdf:resource="&auto-ev;TrafficSignal"/>
 		<rdfs:range rdf:resource="&xsd;decimal"/>
 	</owl:DatatypeProperty>

--- a/MO/MiddleOntology.rdf
+++ b/MO/MiddleOntology.rdf
@@ -78,8 +78,7 @@
 	
 	<owl:Class rdf:about="https://spec.edmcouncil.org/auto/ontology/MO/MiddleOntology/Location">
 		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/auto/ontology/MO/MiddleOntology/ImmaterialEntity"/>
-		<rdfs:label xml:lang="en">location</rdfs:label>
-		<rdfs:label xml:lang="en">place</rdfs:label>
+		<rdfs:label xml:lang="en">Location</rdfs:label>
 		<rdfs:comment>QName: auto-mo-mo:Location</rdfs:comment>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/auto/ontology/MO/MiddleOntology/"/>
 	</owl:Class>

--- a/VC/VehicleCore.rdf
+++ b/VC/VehicleCore.rdf
@@ -3195,7 +3195,6 @@ Typical unit code(s): SEC for seconds&lt;br/&gt;&lt;br/&gt;
 	<owl:ObjectProperty rdf:about="&auto-vc;bodyStyle">
 		<rdfs:subPropertyOf rdf:resource="&owl;topObjectProperty"/>
 		<rdfs:label xml:lang="en">body style</rdfs:label>
-		<rdfs:label xml:lang="en">body type</rdfs:label>
 		<dct:isPartOf rdf:resource="http://auto.schema.org"/>
 		<dct:source rdf:resource="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group"/>
 		<rdfs:isDefinedBy rdf:resource="http://purl.org/vso/ns"/>


### PR DESCRIPTION
Resource [Angle](https://spec.edmcouncil.org/auto/ontology/VS/VehicleSignals/SteeringWheelAngle) doesn't have a label

> Every class, property, and individual must have a label, at a minimum, with additional annotations as described below. It should be the natural language (American English) representation of that entity, space-separated, including the language tag for English.

Resource [Location](https://spec.edmcouncil.org/auto/ontology/MO/MiddleOntology/Location) has multiple labels. 
> FIBO enforces both unique labels and unique names conventions, even across namespaces. There is content in the provisional and informative ontologies that does not adhere to these policies, but for any released ontology, we require unique naming and unique labeling.

Resource [bodyStyle](https://spec.edmcouncil.org/auto/ontology/VC/VehicleCore/bodyStyle) has multiple labels.
> FIBO enforces both unique labels and unique names conventions, even across namespaces. There is content in the provisional and informative ontologies that does not adhere to these policies, but for any released ontology, we require unique naming and unique labeling.
