### PR TITLE
Added labels to 6 classes of VS ontology

### DIFF
--- a/VS/VehicleSignals.rdf
+++ b/VS/VehicleSignals.rdf
@@ -1359,6 +1359,7 @@
 	
 	<owl:Class rdf:about="&auto-vs;DiagnosticSystem">
 		<rdfs:subClassOf rdf:resource="&auto-vs;VehicleSensor"/>
+		<rdfs:label xml:lang="en">Diagnostic system</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&auto-vs;DimmingSystem">
@@ -1543,6 +1544,7 @@
 	
 	<owl:Class rdf:about="&auto-vs;EGRSystemMonitor">
 		<rdfs:subClassOf rdf:resource="&auto-vs;VehicleSensor"/>
+		<rdfs:label xml:lang="en">EGR system monitor</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&auto-vs;EOP">
@@ -1626,6 +1628,7 @@
 	
 	<owl:Class rdf:about="&auto-vs;EVAPSystem">
 		<rdfs:subClassOf rdf:resource="&auto-vs;VehicleSensor"/>
+		<rdfs:label xml:lang="en">EVAP system</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&auto-vs;EVAPVaporPressure">
@@ -1788,6 +1791,7 @@
 	
 	<owl:Class rdf:about="&auto-vs;FluidSensor">
 		<rdfs:subClassOf rdf:resource="&auto-vs;VehicleSensor"/>
+		<rdfs:label xml:lang="en">Fluid sensor</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&auto-vs;FreezeDTC">
@@ -1858,6 +1862,7 @@
 	
 	<owl:Class rdf:about="&auto-vs;FuelPressureSensor">
 		<rdfs:subClassOf rdf:resource="&auto-vs;VehicleSensor"/>
+		<rdfs:label xml:lang="en">Fuel pressure sensor</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&auto-vs;FuelRailPressureAbsolute">
@@ -1898,6 +1903,7 @@
 	
 	<owl:Class rdf:about="&auto-vs;FuelRailPressureSensor">
 		<rdfs:subClassOf rdf:resource="&auto-vs;VehicleSensor"/>
+		<rdfs:label xml:lang="en">Fuel Rail Pressure Sensor</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&auto-vs;FuelRailPressureVac">


### PR DESCRIPTION
The classes the labels were added to: DiagnosticSystem, EGRSystemMonitor, EVAPSystem, FluidSensor, FuelPressureSensor, FuelRailPressureSensor

Signed-off-by: Alex AV <allohant@gmail.com>

Fixes: #130 