### PR TITLE
Multiple labels in MiddleOntology and VehicleCore and missing label in TrafficEnvironment

### DIFF
--- a/DE/TrafficEnvironment.rdf
+++ b/DE/TrafficEnvironment.rdf
@@ -926,6 +926,7 @@
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&auto-ev;angle">
+		<rdfs:label>angle</rdfs:label>
 		<rdfs:domain rdf:resource="&auto-ev;TrafficSignal"/>
 		<rdfs:range rdf:resource="&xsd;decimal"/>
 	</owl:DatatypeProperty>

--- a/MO/MiddleOntology.rdf
+++ b/MO/MiddleOntology.rdf
@@ -79,7 +79,6 @@
 	<owl:Class rdf:about="https://spec.edmcouncil.org/auto/ontology/MO/MiddleOntology/Location">
 		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/auto/ontology/MO/MiddleOntology/ImmaterialEntity"/>
 		<rdfs:label xml:lang="en">location</rdfs:label>
-		<rdfs:label xml:lang="en">place</rdfs:label>
 		<rdfs:comment>QName: auto-mo-mo:Location</rdfs:comment>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/auto/ontology/MO/MiddleOntology/"/>
 	</owl:Class>

--- a/MO/MiddleOntology.rdf
+++ b/MO/MiddleOntology.rdf
@@ -79,6 +79,7 @@
 	<owl:Class rdf:about="https://spec.edmcouncil.org/auto/ontology/MO/MiddleOntology/Location">
 		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/auto/ontology/MO/MiddleOntology/ImmaterialEntity"/>
 		<rdfs:label xml:lang="en">location</rdfs:label>
+		<fibo-fnd-utl-av:synonym xml:lang="en">place</fibo-fnd-utl-av:synonym>
 		<rdfs:comment>QName: auto-mo-mo:Location</rdfs:comment>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/auto/ontology/MO/MiddleOntology/"/>
 	</owl:Class>

--- a/VC/VehicleCore.rdf
+++ b/VC/VehicleCore.rdf
@@ -3194,7 +3194,7 @@ Typical unit code(s): SEC for seconds&lt;br/&gt;&lt;br/&gt;
 	
 	<owl:ObjectProperty rdf:about="&auto-vc;bodyStyle">
 		<rdfs:subPropertyOf rdf:resource="&owl;topObjectProperty"/>
-		<rdfs:label xml:lang="en">body style</rdfs:label>
+		<rdfs:comment xml:lang="en">body style</rdfs:comment>
 		<rdfs:label xml:lang="en">body type</rdfs:label>
 		<dct:isPartOf rdf:resource="http://auto.schema.org"/>
 		<dct:source rdf:resource="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group"/>

--- a/VC/VehicleCore.rdf
+++ b/VC/VehicleCore.rdf
@@ -3194,8 +3194,8 @@ Typical unit code(s): SEC for seconds&lt;br/&gt;&lt;br/&gt;
 	
 	<owl:ObjectProperty rdf:about="&auto-vc;bodyStyle">
 		<rdfs:subPropertyOf rdf:resource="&owl;topObjectProperty"/>
-		<rdfs:comment xml:lang="en">body style</rdfs:comment>
-		<rdfs:label xml:lang="en">body type</rdfs:label>
+		<rdfs:label xml:lang="en">body style</rdfs:label>
+		<fibo-fnd-utl-av:synonym xml:lang="en">body type</fibo-fnd-utl-av:synonym>
 		<dct:isPartOf rdf:resource="http://auto.schema.org"/>
 		<dct:source rdf:resource="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group"/>
 		<rdfs:isDefinedBy rdf:resource="http://purl.org/vso/ns"/>


### PR DESCRIPTION
Resource [Angle](https://spec.edmcouncil.org/auto/ontology/VS/VehicleSignals/SteeringWheelAngle) doesn't have a label

> Every class, property, and individual must have a label, at a minimum, with additional annotations as described below. It should be the natural language (American English) representation of that entity, space-separated, including the language tag for English.

Resource [Location](https://spec.edmcouncil.org/auto/ontology/MO/MiddleOntology/Location) has multiple labels. 
> FIBO enforces both unique labels and unique names conventions, even across namespaces. There is content in the provisional and informative ontologies that does not adhere to these policies, but for any released ontology, we require unique naming and unique labeling.

Resource [bodyStyle](https://spec.edmcouncil.org/auto/ontology/VC/VehicleCore/bodyStyle) has multiple labels.
> FIBO enforces both unique labels and unique names conventions, even across namespaces. There is content in the provisional and informative ontologies that does not adhere to these policies, but for any released ontology, we require unique naming and unique labeling.
