### PR TITLE
Added labels to 6 classes of VS ontology

### DIFF
--- a/VS/VehicleSignals.rdf
+++ b/VS/VehicleSignals.rdf
@@ -846,7 +846,6 @@
 	
 	<owl:Class rdf:about="&auto-vs;CAN">
 		<rdfs:subClassOf rdf:resource="&sosa;Sensor"/>
-		<rdfs:label xml:lang="en">CAN</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&auto-vs;Camera">
@@ -874,7 +873,6 @@
 	
 	<owl:Class rdf:about="&auto-vs;CatalystTemperatureSensor">
 		<rdfs:subClassOf rdf:resource="&auto-vs;VehicleSensor"/>
-		<rdfs:label xml:lang="en">catalyst temperature sensor</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&auto-vs;ChildLock">
@@ -1025,7 +1023,6 @@
 	
 	<owl:Class rdf:about="&auto-vs;CoolantTemperatureSensor">
 		<rdfs:subClassOf rdf:resource="&auto-vs;VehicleSensor"/>
-		<rdfs:label xml:lang="en">coolant temperature sensor</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&auto-vs;CoolantThermometer">
@@ -1036,7 +1033,6 @@
 	
 	<owl:Class rdf:about="&auto-vs;CrankshaftPositionSensor">
 		<rdfs:subClassOf rdf:resource="&auto-vs;VehicleSensor"/>
-		<rdfs:label xml:lang="en">crankshaft position sensor</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&auto-vs;CruiseControlError">
@@ -1230,7 +1226,6 @@
 	
 	<owl:Class rdf:about="&auto-vs;CushionPositionSensor">
 		<rdfs:subClassOf rdf:resource="&auto-vs;VehicleSensor"/>
-		<rdfs:label xml:lang="en">cushion position sensor</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&auto-vs;CushionUp">
@@ -1364,6 +1359,7 @@
 	
 	<owl:Class rdf:about="&auto-vs;DiagnosticSystem">
 		<rdfs:subClassOf rdf:resource="&auto-vs;VehicleSensor"/>
+		<rdfs:label xml:lang="en">diagnostic system</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&auto-vs;DimmingSystem">
@@ -1548,6 +1544,7 @@
 	
 	<owl:Class rdf:about="&auto-vs;EGRSystemMonitor">
 		<rdfs:subClassOf rdf:resource="&auto-vs;VehicleSensor"/>
+		<rdfs:label xml:lang="en">EGR system monitor</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&auto-vs;EOP">
@@ -1631,6 +1628,7 @@
 	
 	<owl:Class rdf:about="&auto-vs;EVAPSystem">
 		<rdfs:subClassOf rdf:resource="&auto-vs;VehicleSensor"/>
+		<rdfs:label xml:lang="en">EVAP system</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&auto-vs;EVAPVaporPressure">
@@ -1793,6 +1791,7 @@
 	
 	<owl:Class rdf:about="&auto-vs;FluidSensor">
 		<rdfs:subClassOf rdf:resource="&auto-vs;VehicleSensor"/>
+		<rdfs:label xml:lang="en">fluid sensor</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&auto-vs;FreezeDTC">
@@ -1863,6 +1862,7 @@
 	
 	<owl:Class rdf:about="&auto-vs;FuelPressureSensor">
 		<rdfs:subClassOf rdf:resource="&auto-vs;VehicleSensor"/>
+		<rdfs:label xml:lang="en">fuel pressure sensor</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&auto-vs;FuelRailPressureAbsolute">
@@ -1903,6 +1903,7 @@
 	
 	<owl:Class rdf:about="&auto-vs;FuelRailPressureSensor">
 		<rdfs:subClassOf rdf:resource="&auto-vs;VehicleSensor"/>
+		<rdfs:label xml:lang="en">fuel rail pressure sensor</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&auto-vs;FuelRailPressureVac">
@@ -2295,7 +2296,6 @@
 	
 	<owl:Class rdf:about="&auto-vs;Intake-AirTemperatureSensor">
 		<rdfs:subClassOf rdf:resource="&auto-vs;VehicleSensor"/>
-		<rdfs:label xml:lang="en">intake air temperature sensor</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&auto-vs;IntakeTemperature">
@@ -2342,7 +2342,6 @@
 	
 	<owl:Class rdf:about="&auto-vs;IsBackUpLightOn">
 		<rdfs:subClassOf rdf:resource="&auto-vs;ActuableSignal"/>
-		<rdfs:label xml:lang="en">is backup light on</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&auto-vs;IsBackupLightOn">
@@ -2961,7 +2960,6 @@
 	
 	<owl:Class rdf:about="&auto-vs;LeftIndicatorLight">
 		<rdfs:subClassOf rdf:resource="&auto-vs;ActuableSignal"/>
-		<rdfs:label xml:lang="en">left indicator light</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&auto-vs;LeftIndicatorSwitch">
@@ -2972,7 +2970,6 @@
 	
 	<owl:Class rdf:about="&auto-vs;Lidar">
 		<rdfs:subClassOf rdf:resource="&sosa;Sensor"/>
-		<rdfs:label xml:lang="en">lidar</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&auto-vs;LightIntensity">
@@ -3194,7 +3191,6 @@
 	
 	<owl:Class rdf:about="&auto-vs;LumbarPressureSensor">
 		<rdfs:subClassOf rdf:resource="&auto-vs;VehicleSensor"/>
-		<rdfs:label xml:lang="en">lumbar pressure sensor</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&auto-vs;LumbarUp">
@@ -3229,7 +3225,6 @@
 	
 	<owl:Class rdf:about="&auto-vs;MAFSensor">
 		<rdfs:subClassOf rdf:resource="&auto-vs;VehicleSensor"/>
-		<rdfs:label xml:lang="en">MAF sensor</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&auto-vs;MAP">
@@ -4035,7 +4030,6 @@
 	
 	<owl:Class rdf:about="&auto-vs;RightIndicatorLight">
 		<rdfs:subClassOf rdf:resource="&auto-vs;ActuableSignal"/>
-		<rdfs:label xml:lang="en">right indicator light</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&auto-vs;RightIndicatorSwitch">
@@ -4377,7 +4371,6 @@
 	
 	<owl:Class rdf:about="&auto-vs;Sonar">
 		<rdfs:subClassOf rdf:resource="&sosa;Sensor"/>
-		<rdfs:label xml:lang="en">sonar</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&auto-vs;SpeedSet">
@@ -4700,7 +4693,6 @@
 	
 	<owl:Class rdf:about="&auto-vs;ThrottleActuator">
 		<rdfs:subClassOf rdf:resource="&sosa;Actuator"/>
-		<rdfs:label xml:lang="en">throttle actuator</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&auto-vs;ThrottlePosition">
@@ -5097,7 +5089,6 @@
 	
 	<owl:Class rdf:about="&auto-vs;VoltageSensor">
 		<rdfs:subClassOf rdf:resource="&auto-vs;VehicleSensor"/>
-		<rdfs:label xml:lang="en">voltage sensor</rdfs:label>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&auto-vs;WarmupsSinceDTCClear">


### PR DESCRIPTION
The classes the labels were added to: DiagnosticSystem, EGRSystemMonitor, EVAPSystem, FluidSensor, FuelPressureSensor, FuelRailPressureSensor

Signed-off-by: Alex AV [allohant@gmail.com](mailto:allohant@gmail.com)

Fixes: https://github.com/edmcouncil/auto/issues/130